### PR TITLE
release 0.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: clintrialx
 Type: Package
 Title: Connect and Work with Clinical Trials Data Sources
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: 
     person("Indraneel", "Chakraborty",, "hello.indraneel@gmail.com", 
            role = c("aut", "cre"), comment = c(ORCID = "0000-0001-6958-8269"))
@@ -21,10 +21,9 @@ Imports:
     RPostgreSQL, 
     tibble, 
     DBI,
-    rmarkdown,
-    xfun (>= 0.44)
+    rmarkdown
 Suggests: 
     knitr
 VignetteBuilder: knitr
 RoxygenNote: 7.3.2
-URL: http://www.indraneelchakraborty.com/clintrialx/
+URL: http://www.indraneelchakraborty.com/clintrialx/, https://github.com/ineelhere/clintrialx

--- a/R/aact_query.R
+++ b/R/aact_query.R
@@ -6,7 +6,7 @@
 #' @import DBI
 #' @import RPostgreSQL
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' # Set environment variables for database credentials in .Renviron and load it
 #' # readRenviron(".Renviron")
 #'
@@ -32,7 +32,7 @@ aact_connection <- function(user, password) {
 #' @return A data frame with distinct study types
 #' @import DBI
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' # Set environment variables for database credentials in .Renviron and load it
 #' # readRenviron(".Renviron")
 #'
@@ -58,7 +58,7 @@ aact_check_connection <- function(con) {
 #' @return A data frame with the query results
 #' @import DBI
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' # Set environment variables for database credentials in .Renviron and load it
 #' # readRenviron(".Renviron")
 #'

--- a/R/ctg_bulk_fetch.R
+++ b/R/ctg_bulk_fetch.R
@@ -37,7 +37,7 @@
 #'
 #'
 #' @examples
-#' \donttest{
+#' \dontrun{
 #' trials <- ctg_bulk_fetch(location="india")
 #' }
 #' @export

--- a/README.Rmd
+++ b/README.Rmd
@@ -137,7 +137,7 @@ df <- ctg_bulk_fetch(location="india")
 
 #### Run Custom Queries
 
-```{r example4, eval = FALSE}
+```
 # Set environment variables for database credentials in .Renviron and load it
 # readRenviron(".Renviron")
 

--- a/README.md
+++ b/README.md
@@ -123,20 +123,18 @@ df <- ctg_bulk_fetch(location="india")
 
 #### Run Custom Queries
 
-``` r
-# Set environment variables for database credentials in .Renviron and load it
-# readRenviron(".Renviron")
+    # Set environment variables for database credentials in .Renviron and load it
+    # readRenviron(".Renviron")
 
-# Connect to the database
-con <- aact_connection(Sys.getenv('user'), Sys.getenv('password'))
+    # Connect to the database
+    con <- aact_connection(Sys.getenv('user'), Sys.getenv('password'))
 
-# Run a custom query
-query <- "SELECT nct_id, source, enrollment, overall_status FROM studies LIMIT 5;"
-results <- aact_custom_query(con, query)
+    # Run a custom query
+    query <- "SELECT nct_id, source, enrollment, overall_status FROM studies LIMIT 5;"
+    results <- aact_custom_query(con, query)
 
-# Print the results
-print(results)
-```
+    # Print the results
+    print(results)
 
 ## Trial Data HTML Reports
 

--- a/clintrialx.Rproj
+++ b/clintrialx.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 4ed8760c-a463-4485-adb4-e4259224454e
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/man/aact_check_connection.Rd
+++ b/man/aact_check_connection.Rd
@@ -16,7 +16,7 @@ A data frame with distinct study types
 Check database connection
 }
 \examples{
-\donttest{
+\dontrun{
 # Set environment variables for database credentials in .Renviron and load it
 # readRenviron(".Renviron")
 

--- a/man/aact_connection.Rd
+++ b/man/aact_connection.Rd
@@ -18,7 +18,7 @@ A connection object to the AACT database
 Connect to AACT PostgreSQL database
 }
 \examples{
-\donttest{
+\dontrun{
 # Set environment variables for database credentials in .Renviron and load it
 # readRenviron(".Renviron")
 

--- a/man/aact_custom_query.Rd
+++ b/man/aact_custom_query.Rd
@@ -18,7 +18,7 @@ A data frame with the query results
 Run a custom query
 }
 \examples{
-\donttest{
+\dontrun{
 # Set environment variables for database credentials in .Renviron and load it
 # readRenviron(".Renviron")
 

--- a/man/ctg_bulk_fetch.Rd
+++ b/man/ctg_bulk_fetch.Rd
@@ -50,7 +50,7 @@ This function retrieves clinical trial data in bulk from the ClinicalTrials.gov 
 specified parameters. It handles pagination and returns a combined dataset.
 }
 \examples{
-\donttest{
+\dontrun{
 trials <- ctg_bulk_fetch(location="india")
 }
 }


### PR DESCRIPTION
- Updated package version and imports.
- Wrapped API-dependent code inside `\dontrun{}` in some examples to comply with CRAN policies on internet access.
